### PR TITLE
Prioritize text over background

### DIFF
--- a/h.js
+++ b/h.js
@@ -57,12 +57,6 @@ document.addEventListener("DOMContentLoaded", function() {
 		}   
 	}
 
-	spaIfy();
-
-	document.title = title;
-
-	generateBgRows(bgRowHeight, 42); // Generate the background divs that offset the rainbow pattern
-
 	if (text) {
 
 		let dividedString = divideString(text);
@@ -73,6 +67,12 @@ document.addEventListener("DOMContentLoaded", function() {
 		
 		moveAround(textDiv);
 	}
+
+	spaIfy();
+
+	document.title = title;
+
+	generateBgRows(bgRowHeight, 42); // Generate the background divs that offset the rainbow pattern
 
 	if (audioFile) {
 		const audioPlayer = new Audio(audioFile);


### PR DESCRIPTION
This gets the text moving faster. In a lot of browsers, including my own, this gets rid of a 1-to-2-second delay between first full render and the beginning of the text's animation, resulting in the text moving right away.